### PR TITLE
Refactoring / Resolve Full Stream URL

### DIFF
--- a/app/src/main/java/com/tinnvec/dctvandroid/ChannelListAdapter.java
+++ b/app/src/main/java/com/tinnvec/dctvandroid/ChannelListAdapter.java
@@ -57,8 +57,8 @@ public class ChannelListAdapter extends RecyclerView.Adapter<ChannelListAdapter.
     @Override
     public void onBindViewHolder(ChannelViewHolder holder, int position) {
         final AbstractChannel chan = channelList.get(position);
-
-        new ImageDownloaderTask(holder.channelArt).execute(chan.getImageAssetUrl());
+        if (chan.getImageAssetUrl() != null)
+            new ImageDownloaderTask(holder.channelArt).execute(chan.getImageAssetUrl());
 
         holder.channelName.setText(chan.getFriendlyAlias());
         holder.channelName.setSelected(true);

--- a/app/src/main/java/com/tinnvec/dctvandroid/PlayStreamActivity.java
+++ b/app/src/main/java/com/tinnvec/dctvandroid/PlayStreamActivity.java
@@ -568,11 +568,14 @@ public class PlayStreamActivity extends AppCompatActivity {
     }
 
     private void videoQualityChanged() {
-        if (mLocation.equals(PlaybackLocation.LOCAL) && mPlaybackState.equals(PlaybackState.PLAYING)) {
+        this.streamUrl = channel.getStreamUrl(appConfig, currentQuality);
+        if (mLocation == PlaybackLocation.LOCAL && mPlaybackState == PlaybackState.PLAYING) {
             vidView.pause();
-            this.streamUrl = channel.getStreamUrl(appConfig, currentQuality);
             vidView.setVideoURI(Uri.parse(this.streamUrl));
             vidView.start();
+        } else if (mCastSession != null && mCastSession.isConnected()) {
+            // reload chromecast
+            loadRemoteMedia(true);
         }
     }
 

--- a/app/src/main/java/com/tinnvec/dctvandroid/PlayStreamActivity.java
+++ b/app/src/main/java/com/tinnvec/dctvandroid/PlayStreamActivity.java
@@ -569,10 +569,8 @@ public class PlayStreamActivity extends AppCompatActivity {
 
     private void videoQualityChanged() {
         this.streamUrl = channel.getStreamUrl(appConfig, currentQuality);
-        if (mLocation == PlaybackLocation.LOCAL && mPlaybackState == PlaybackState.PLAYING) {
-            vidView.pause();
-            vidView.setVideoURI(Uri.parse(this.streamUrl));
-            vidView.start();
+        if (mLocation == PlaybackLocation.LOCAL) {
+            vidView.setVideoPath(this.streamUrl);
         } else if (mCastSession != null && mCastSession.isConnected()) {
             // reload chromecast
             loadRemoteMedia(true);
@@ -602,7 +600,7 @@ public class PlayStreamActivity extends AppCompatActivity {
                 break;
 
             case IDLE:
-                vidView.setVideoURI(Uri.parse(streamUrl));
+                vidView.setVideoPath(streamUrl);
                 vidView.start();
                 mPlaybackState = PLAYING;
                 break;

--- a/app/src/main/java/com/tinnvec/dctvandroid/PlayStreamActivity.java
+++ b/app/src/main/java/com/tinnvec/dctvandroid/PlayStreamActivity.java
@@ -55,6 +55,7 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.concurrent.ExecutionException;
 
 import io.vov.vitamio.MediaPlayer;
 import io.vov.vitamio.Vitamio;
@@ -70,7 +71,7 @@ public class PlayStreamActivity extends AppCompatActivity {
     private final Handler mHandler = new Handler();
     private ProgressDialog progressDialog;
     private VideoView vidView;
-    private String dctvBaseUrl;
+    private String streamUrl;
     //converted to global for interaction with cast methods
     private AbstractChannel channel;
     // added for cast SDK v3
@@ -95,6 +96,10 @@ public class PlayStreamActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         Vitamio.isInitialized(getApplicationContext());
 
+        channel = getIntent().getExtras().getParcelable(LiveChannelsActivity.CHANNEL_DATA);
+        if (channel == null)
+            throw new NullPointerException("No Channel passed to PlayStreamActivity");
+
         PreferenceManager.setDefaultValues(this, R.xml.preferences, false);
         PropertyReader pReader = new PropertyReader(this);
         appConfig = pReader.getMyProperties("app.properties");
@@ -104,12 +109,11 @@ public class PlayStreamActivity extends AppCompatActivity {
         requestWindowFeature(Window.FEATURE_NO_TITLE);
         supportRequestWindowFeature(Window.FEATURE_ACTION_BAR_OVERLAY);
 
-        this.dctvBaseUrl = appConfig.getProperty("api.dctv.base_url");
-
         setContentView(R.layout.activity_play_stream);
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
 
         currentQuality = Quality.valueOf(sharedPreferences.getString("stream_quality", "high").toUpperCase());
+        this.streamUrl = channel.getStreamUrl(appConfig, currentQuality);
 
         // for cast SDK v3
 //        setupControlsCallbacks();
@@ -118,9 +122,6 @@ public class PlayStreamActivity extends AppCompatActivity {
         mCastContext.registerLifecycleCallbacksBeforeIceCreamSandwich(this, savedInstanceState);
         mCastSession = mCastContext.getSessionManager().getCurrentCastSession();
 
-        channel = getIntent().getExtras().getParcelable(LiveChannelsActivity.CHANNEL_DATA);
-        if (channel == null)
-            throw new NullPointerException("No Channel passed to PlayStreamActivity");
         String title = channel.getFriendlyAlias();
         title = title != null ? title : "Unknown";
 
@@ -190,8 +191,8 @@ public class PlayStreamActivity extends AppCompatActivity {
         chatWebview.loadUrl(url);
 
         try {
-            vidView.setVideoPath(channel.getStreamUrl(appConfig, currentQuality));
-            Log.d(TAG, "Setting url of the VideoView to: " + channel.getStreamUrl(appConfig, currentQuality));
+            vidView.setVideoPath(streamUrl);
+            Log.d(TAG, "Setting url of the VideoView to: " + streamUrl);
             mPlaybackState = PLAYING;
             updatePlayButton(mPlaybackState);
             if (mCastSession != null && mCastSession.isConnected()) {
@@ -314,41 +315,16 @@ public class PlayStreamActivity extends AppCompatActivity {
         if (channel.getImageAssetUrl() != null)
             movieMetadata.addImage(new WebImage(Uri.parse(channel.getImageAssetUrl())));
 
-        String streamUrl;
-
-        /*
-        // constructing the direct stream url, as the redirect api doesn't work for chromecast
-        */
-
-        if (channel.getName().equals("dctv_247")) {
-            streamUrl = channel.getStreamUrl(appConfig, currentQuality);
-        } else {
-            if (!channel.getName().equals("dctv") && channel instanceof DctvChannel) {
-                if (channel.getName().equals("frogpantsstudios") && channel instanceof DctvChannel) {
-                    streamUrl = "http://ingest.diamondclub.tv/high/" + "scottjohnson" + ".m3u8";
-                } else if (channel.getName().equals("sgtmuffin") && channel instanceof DctvChannel) {
-                    streamUrl = "http://ingest.diamondclub.tv/high/" + "muffin" + ".m3u8";
-                } else if (channel.getName().equals("musicnews") && channel instanceof DctvChannel) {
-                    streamUrl = "http://ingest.diamondclub.tv/high/" + "kristikates" + ".m3u8";
-                } else {
-                    streamUrl = "http://ingest.diamondclub.tv/high/" + channel.getName() + ".m3u8";
-                }
-            } else {
-                Context context = getApplicationContext();
-                CharSequence text = "Sorry, we can't cast this stream for now. Maybe the 24/7 channel shows it?";
-                int duration = Toast.LENGTH_LONG;
-
-                Toast toast = Toast.makeText(context, text, duration);
-                toast.show();
-                updatePlaybackLocation(PlaybackLocation.LOCAL);
-
-                return null;
-            }
+        String resolvedStreamUrl = "";
+        try {
+            resolvedStreamUrl = channel.getResolvedStreamUrl(streamUrl);
+        } catch (InterruptedException | ExecutionException ex) {
+            Log.e(TAG, "Exception when trying to get full Stream URL", ex);
         }
 
-        Log.d(TAG, "Passing this url to ChromeCast: " + streamUrl);
+        Log.d(TAG, "Passing this url to ChromeCast: " + resolvedStreamUrl);
 
-        return new MediaInfo.Builder(streamUrl)
+        return new MediaInfo.Builder(resolvedStreamUrl)
                 .setStreamType(MediaInfo.STREAM_TYPE_LIVE)
                 .setContentType("videos/m3u8")
                 .setMetadata(movieMetadata)
@@ -594,7 +570,8 @@ public class PlayStreamActivity extends AppCompatActivity {
     private void videoQualityChanged() {
         if (mLocation.equals(PlaybackLocation.LOCAL) && mPlaybackState.equals(PlaybackState.PLAYING)) {
             vidView.pause();
-            vidView.setVideoURI(Uri.parse(channel.getStreamUrl(appConfig, currentQuality)));
+            this.streamUrl = channel.getStreamUrl(appConfig, currentQuality);
+            vidView.setVideoURI(Uri.parse(this.streamUrl));
             vidView.start();
         }
     }
@@ -622,7 +599,7 @@ public class PlayStreamActivity extends AppCompatActivity {
                 break;
 
             case IDLE:
-                vidView.setVideoURI(Uri.parse(channel.getStreamUrl(appConfig, currentQuality)));
+                vidView.setVideoURI(Uri.parse(streamUrl));
                 vidView.start();
                 mPlaybackState = PLAYING;
                 break;

--- a/app/src/main/java/com/tinnvec/dctvandroid/PlayStreamActivity.java
+++ b/app/src/main/java/com/tinnvec/dctvandroid/PlayStreamActivity.java
@@ -423,9 +423,11 @@ public class PlayStreamActivity extends AppCompatActivity {
                 builder.setItems(qualities, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        // the user clicked on colors[which]
-                        currentQuality = channel.getAllowedQualities()[which];
-                        videoQualityChanged();
+                        Quality newQuality = channel.getAllowedQualities()[which];
+                        if (newQuality != currentQuality) {
+                            currentQuality = newQuality;
+                            videoQualityChanged();
+                        }
                     }
                 });
                 builder.show();

--- a/app/src/main/java/com/tinnvec/dctvandroid/PlayStreamActivity.java
+++ b/app/src/main/java/com/tinnvec/dctvandroid/PlayStreamActivity.java
@@ -109,7 +109,7 @@ public class PlayStreamActivity extends AppCompatActivity {
         setContentView(R.layout.activity_play_stream);
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
 
-        currentQuality = Quality.valueOf(sharedPreferences.getString("stream_quality", "high"));
+        currentQuality = Quality.valueOf(sharedPreferences.getString("stream_quality", "high").toUpperCase());
 
         // for cast SDK v3
 //        setupControlsCallbacks();
@@ -127,7 +127,7 @@ public class PlayStreamActivity extends AppCompatActivity {
         ImageView channelArtView = (ImageView) findViewById(R.id.channelart);
         String urlChannelart = channel.getImageAssetHDUrl();
 
-        if (!Objects.equals(urlChannelart, "")) {
+        if (urlChannelart != null) {
             Picasso.with(this)
                     .load(urlChannelart)
                     .into(channelArtView);
@@ -309,8 +309,10 @@ public class PlayStreamActivity extends AppCompatActivity {
 
         movieMetadata.putString(MediaMetadata.KEY_SUBTITLE, channel.getName());
         movieMetadata.putString(MediaMetadata.KEY_TITLE, channel.getFriendlyAlias());
-        movieMetadata.addImage(new WebImage(Uri.parse(channel.getImageAssetHDUrl())));
-        movieMetadata.addImage(new WebImage(Uri.parse(channel.getImageAssetUrl())));
+        if (channel.getImageAssetHDUrl() != null)
+            movieMetadata.addImage(new WebImage(Uri.parse(channel.getImageAssetHDUrl())));
+        if (channel.getImageAssetUrl() != null)
+            movieMetadata.addImage(new WebImage(Uri.parse(channel.getImageAssetUrl())));
 
         String streamUrl;
 

--- a/app/src/main/java/com/tinnvec/dctvandroid/SettingsFragment.java
+++ b/app/src/main/java/com/tinnvec/dctvandroid/SettingsFragment.java
@@ -28,7 +28,7 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this.getActivity());
         // Set summary to be the user-description for the selected value
         String chatName = sharedPreferences.getString("chat_name", "");
-        if (chatName != null && !"".equals(chatName)) {
+        if (!chatName.isEmpty()) {
             connectionPref.setSummary(chatName);
         }
 
@@ -38,7 +38,7 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
         qualityPreference.setEntryValues(Quality.allAsStrings());
 
         String streamQuality = sharedPreferences.getString("stream_quality", "");
-        if (streamQuality != null && !"".equals(streamQuality)) {
+        if (!streamQuality.isEmpty()) {
             qualityPreference.setSummary(streamQuality);
         }
     }

--- a/app/src/main/java/com/tinnvec/dctvandroid/channel/AbstractChannel.java
+++ b/app/src/main/java/com/tinnvec/dctvandroid/channel/AbstractChannel.java
@@ -1,11 +1,12 @@
 package com.tinnvec.dctvandroid.channel;
 
-import android.content.Context;
 import android.os.Parcel;
 import android.os.Parcelable;
 
-import java.util.List;
+import com.tinnvec.dctvandroid.tasks.ResolveStreamUrlTask;
+
 import java.util.Properties;
+import java.util.concurrent.ExecutionException;
 
 public abstract class AbstractChannel implements Parcelable {
     int channelID;
@@ -36,13 +37,17 @@ public abstract class AbstractChannel implements Parcelable {
         streamUrl = in.readString();
     }
 
-    public abstract String getStreamUrl(Properties app_conf, Quality quality);
-
-    public String getDirectStreamUrl(Properties app_config, Quality quality) {
-        String url = getStreamUrl(app_config, quality);
-        throw new UnsupportedOperationException("need to implement method");
+    public String getStreamUrl(Properties app_config, Quality quality) {
+        if (streamUrl != null) return streamUrl;
+        String baseUrl = app_config.getProperty("api.dctv.base_url");
+        String url = String.format("%sapi/hlsredirect.php?c=%d&q=%s", baseUrl, channelID, quality.toString().toLowerCase());
+        return url;
     }
 
+    public String getResolvedStreamUrl(String url) throws ExecutionException, InterruptedException{
+        ResolveStreamUrlTask task = new ResolveStreamUrlTask();
+        return task.execute(url).get();
+    }
 
     public abstract Quality[] getAllowedQualities();
 

--- a/app/src/main/java/com/tinnvec/dctvandroid/channel/ChannelReader.java
+++ b/app/src/main/java/com/tinnvec/dctvandroid/channel/ChannelReader.java
@@ -37,8 +37,8 @@ public class ChannelReader {
         chan.setNowOnline(nowonline.equals("yes"));
         chan.setHasAlerts(alerts);
         chan.setDescription(twitch_yt_description);
-        chan.setImageAssetUrl(imageasset);
-        chan.setImageAssetHDUrl(imageassethd);
+        chan.setImageAssetUrl(imageasset.isEmpty() ? null : imageasset);
+        chan.setImageAssetHDUrl(imageassethd.isEmpty() ? null : imageassethd);
         chan.setUrlToPlayer(urltoplayer);
     }
 

--- a/app/src/main/java/com/tinnvec/dctvandroid/channel/DctvChannel.java
+++ b/app/src/main/java/com/tinnvec/dctvandroid/channel/DctvChannel.java
@@ -1,14 +1,8 @@
 package com.tinnvec.dctvandroid.channel;
 
-import android.content.Context;
 import android.os.Parcel;
 
-import com.tinnvec.dctvandroid.R;
-
-import java.util.List;
 import java.util.Properties;
-
-import static android.R.attr.format;
 
 public class DctvChannel extends AbstractChannel {
 
@@ -42,13 +36,6 @@ public class DctvChannel extends AbstractChannel {
         return chan;
     }
 
-    @Override
-    public String getStreamUrl(Properties app_config, Quality quality) {
-        if (streamUrl != null) return streamUrl;
-        String baseUrl = app_config.getProperty("api.dctv.base_url");
-        String url = String.format("%sapi/hlsredirect.php?c=%d&q=%s", baseUrl, channelID, quality.toString().toLowerCase());
-        return url;
-    }
 
     @Override
     public Quality[] getAllowedQualities() {

--- a/app/src/main/java/com/tinnvec/dctvandroid/channel/DctvChannel.java
+++ b/app/src/main/java/com/tinnvec/dctvandroid/channel/DctvChannel.java
@@ -46,7 +46,7 @@ public class DctvChannel extends AbstractChannel {
     public String getStreamUrl(Properties app_config, Quality quality) {
         if (streamUrl != null) return streamUrl;
         String baseUrl = app_config.getProperty("api.dctv.base_url");
-        String url = String.format("%sapi/hlsredirect.php?c=%d&q=%s", baseUrl, channelID, quality.toString());
+        String url = String.format("%sapi/hlsredirect.php?c=%d&q=%s", baseUrl, channelID, quality.toString().toLowerCase());
         return url;
     }
 

--- a/app/src/main/java/com/tinnvec/dctvandroid/channel/Quality.java
+++ b/app/src/main/java/com/tinnvec/dctvandroid/channel/Quality.java
@@ -6,9 +6,9 @@ package com.tinnvec.dctvandroid.channel;
  * Created by kev on 11/14/16.
  */
 public enum Quality {
-    source,
-    high,
-    low;
+    SOURCE,
+    HIGH,
+    LOW;
 
     public static String[] allAsStrings() {
         return allAsStrings(values());
@@ -21,7 +21,7 @@ public enum Quality {
     public static String[] allAsStrings(Quality[] enums) {
         String[] vals = new String[enums.length];
         for (int i = 0; i < enums.length; i++) {
-            vals[i] = enums[i].toString();
+            vals[i] = enums[i].toString().toLowerCase();
         }
         return vals;
     }

--- a/app/src/main/java/com/tinnvec/dctvandroid/channel/TwitchChannel.java
+++ b/app/src/main/java/com/tinnvec/dctvandroid/channel/TwitchChannel.java
@@ -1,12 +1,7 @@
 package com.tinnvec.dctvandroid.channel;
 
 
-import android.content.Context;
 import android.os.Parcel;
-
-import com.tinnvec.dctvandroid.R;
-
-import java.util.Properties;
 
 public class TwitchChannel extends AbstractChannel {
     public static final Creator<TwitchChannel> CREATOR = new Creator<TwitchChannel>() {
@@ -26,13 +21,6 @@ public class TwitchChannel extends AbstractChannel {
     public TwitchChannel(Parcel in) {
         super(in);
         currentGame = in.readString();
-    }
-    @Override
-    public String getStreamUrl(Properties app_config, Quality quality) {
-        if (streamUrl != null) return streamUrl;
-        String baseUrl = app_config.getProperty("api.dctv.base_url");
-        String url = String.format("%sapi/hlsredirect.php?c=%d&q=%s", baseUrl, channelID, quality.toString().toLowerCase());
-        return url;
     }
 
     @Override

--- a/app/src/main/java/com/tinnvec/dctvandroid/channel/TwitchChannel.java
+++ b/app/src/main/java/com/tinnvec/dctvandroid/channel/TwitchChannel.java
@@ -31,7 +31,7 @@ public class TwitchChannel extends AbstractChannel {
     public String getStreamUrl(Properties app_config, Quality quality) {
         if (streamUrl != null) return streamUrl;
         String baseUrl = app_config.getProperty("api.dctv.base_url");
-        String url = String.format("%sapi/hlsredirect.php?c=%d&q=%s", baseUrl, channelID, quality.toString());
+        String url = String.format("%sapi/hlsredirect.php?c=%d&q=%s", baseUrl, channelID, quality.toString().toLowerCase());
         return url;
     }
 

--- a/app/src/main/java/com/tinnvec/dctvandroid/channel/YoutubeChannel.java
+++ b/app/src/main/java/com/tinnvec/dctvandroid/channel/YoutubeChannel.java
@@ -40,7 +40,7 @@ public class YoutubeChannel extends AbstractChannel {
 
     @Override
     public Quality[] getAllowedQualities() {
-        return new Quality[] {Quality.high};
+        return new Quality[] {Quality.HIGH};
     }
 
     @Override

--- a/app/src/main/java/com/tinnvec/dctvandroid/tasks/ResolveStreamUrlTask.java
+++ b/app/src/main/java/com/tinnvec/dctvandroid/tasks/ResolveStreamUrlTask.java
@@ -1,0 +1,49 @@
+package com.tinnvec.dctvandroid.tasks;
+
+import android.os.AsyncTask;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+/**
+ * Created by robin on 15.11.16.
+ */
+
+public class ResolveStreamUrlTask  extends AsyncTask<String, Void, String> {
+
+    private IOException exception;
+
+    @Override
+    protected String doInBackground(String... params) {
+        try {
+            return resolveStreamUrl(params[0]);
+        } catch (IOException ex) {
+            this.exception = ex;
+            return null;
+        }
+    }
+
+    private String resolveStreamUrl(String streamUrl) throws IOException {
+        URL url = new URL(streamUrl);
+        HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
+        urlConnection.setInstanceFollowRedirects(true);
+        urlConnection.connect();
+        urlConnection.getHeaderFields();
+        int responseCode = urlConnection.getResponseCode();
+        if (responseCode == HttpURLConnection.HTTP_MOVED_PERM
+                || responseCode == HttpURLConnection.HTTP_MOVED_TEMP) {
+            String redirectUrl = urlConnection.getHeaderField("Location");
+            return resolveStreamUrl(redirectUrl);
+        }
+        return streamUrl;
+    }
+
+    @Override
+    protected void onPostExecute(String s) {
+        if (this.exception != null) {
+            // TODO: Handle exception properly
+            exception.printStackTrace();
+        }
+    }
+}

--- a/app/src/main/java/com/tinnvec/dctvandroid/tasks/ResolveStreamUrlTask.java
+++ b/app/src/main/java/com/tinnvec/dctvandroid/tasks/ResolveStreamUrlTask.java
@@ -36,7 +36,7 @@ public class ResolveStreamUrlTask  extends AsyncTask<String, Void, String> {
             String redirectUrl = urlConnection.getHeaderField("Location");
             return resolveStreamUrl(redirectUrl);
         }
-        return streamUrl;
+        return urlConnection.getURL().toString();
     }
 
     @Override


### PR DESCRIPTION
I implemented the method to fully resolve a stream url (follow redirections). When casting, this method is used, otherwise the redirect URL from the DC.tv API is passed directly to vitamino (it could be used for that too, but there's more exception handling involved with the extra method)

Also a bit of refactoring and fixes, see commit messages for details

Tested with the 24/7 channel and frogpants over MuffinCDN, with phone and chromecast